### PR TITLE
feat(jenkins) allow polling to be turned off

### DIFF
--- a/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/JenkinsProperties.groovy
+++ b/igor-web/src/main/groovy/com/netflix/spinnaker/igor/config/JenkinsProperties.groovy
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.igor.config
 import groovy.transform.CompileStatic
 import org.hibernate.validator.constraints.NotEmpty
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.NestedConfigurationProperty
 
 import javax.validation.Valid
 
@@ -28,6 +29,14 @@ import javax.validation.Valid
 @CompileStatic
 @ConfigurationProperties(prefix = 'jenkins')
 class JenkinsProperties {
+
+    @NestedConfigurationProperty
+    final Polling polling = new Polling()
+
+    static class Polling {
+        boolean enabled = true
+    }
+
     @Valid
     List<JenkinsHost> masters
 

--- a/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSchedulingSpec.groovy
+++ b/igor-web/src/test/groovy/com/netflix/spinnaker/igor/jenkins/JenkinsBuildMonitorSchedulingSpec.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.igor.jenkins
 
 import com.netflix.spinnaker.igor.IgorConfigurationProperties
+import com.netflix.spinnaker.igor.config.JenkinsProperties
 import com.netflix.spinnaker.igor.jenkins.client.model.ProjectsList
 import com.netflix.spinnaker.igor.jenkins.service.JenkinsService
 import com.netflix.spinnaker.igor.model.BuildServiceProvider
@@ -47,7 +48,8 @@ class JenkinsBuildMonitorSchedulingSpec extends Specification {
         BuildMasters buildMasters = Mock(BuildMasters)
         def cfg = new IgorConfigurationProperties()
         cfg.spinnaker.build.pollInterval = 1
-        monitor = new JenkinsBuildMonitor(cache: cache, buildMasters: buildMasters, igorConfigurationProperties: cfg)
+        def jenkinsConfig = new JenkinsProperties()
+        monitor = new JenkinsBuildMonitor(cache: cache, buildMasters: buildMasters, igorConfigurationProperties: cfg, jenkinsProperties: jenkinsConfig)
         monitor.worker = scheduler.createWorker()
 
         when:
@@ -81,6 +83,45 @@ class JenkinsBuildMonitorSchedulingSpec extends Specification {
         4 * buildMasters.filteredMap(BuildServiceProvider.JENKINS) >> [MASTER: jenkinsService]
         4 * buildMasters.map >> [MASTER: jenkinsService]
         4 * jenkinsService.projects >> PROJECTS
+
+        cleanup:
+        monitor.stop()
+    }
+
+    void 'scheduler can be turned off'() {
+        given:
+        cache.getJobNames(MASTER) >> []
+        BuildMasters buildMasters = Mock(BuildMasters)
+        def cfg = new IgorConfigurationProperties()
+        cfg.spinnaker.build.pollInterval = 1
+        def jenkinsConfig = new JenkinsProperties()
+        jenkinsConfig.polling.enabled = false
+        monitor = new JenkinsBuildMonitor(cache: cache, buildMasters: buildMasters, igorConfigurationProperties: cfg, jenkinsProperties: jenkinsConfig)
+        monitor.worker = scheduler.createWorker()
+
+        when:
+        monitor.onApplicationEvent(Mock(ContextRefreshedEvent))
+        scheduler.advanceTimeBy(1L, TimeUnit.SECONDS.MILLISECONDS)
+
+        then: 'initial poll'
+        0 * buildMasters.filteredMap(BuildServiceProvider.JENKINS) >> [MASTER: jenkinsService]
+        0 * buildMasters.map >> [MASTER: jenkinsService]
+        0 * jenkinsService.projects >> PROJECTS
+
+        when:
+        scheduler.advanceTimeBy(998L, TimeUnit.SECONDS.MILLISECONDS)
+
+        then:
+        0 * buildMasters.map >> [MASTER: jenkinsService]
+        0 * jenkinsService.projects >> PROJECTS
+
+        when: 'poll at 1 second'
+        scheduler.advanceTimeBy(2L, TimeUnit.SECONDS.MILLISECONDS)
+
+        then:
+        0 * buildMasters.filteredMap(BuildServiceProvider.JENKINS) >> [MASTER: jenkinsService]
+        0 * buildMasters.map >> [MASTER: jenkinsService]
+        0 * jenkinsService.projects >> PROJECTS
 
         cleanup:
         monitor.stop()


### PR DESCRIPTION
Adding the ability to turn off jenkins polling. Its now possible to run multiple igors without duplicate notifications to echo.

Best viewed without whitespace changes (however, line commenting is not possible)
https://github.com/armory-io/igor/pull/1/files?w=1 

#### Key take aways
- polling is on by default
- igor's api still servers the jenkins info
- no jenkins events are sent to echo
- any changes in jenkins does not persist to cache
- there must be at least 1 polling igor to kick off jobs.